### PR TITLE
型エラー関係の修正

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 2
+indent_style = space

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.typeCheckingMode": "basic"
+}


### PR DESCRIPTION
VSCode で Python (Pylance) の Type Checking を basic に設定すると、型エラーが大量に発生してしまっていました。
エラーを追っていくうちに明らかにコーディングミス、型定義ミスと思われる箇所もあったので、同時に修正してあります。

「どう考えてもこの行が実行されるタイミングでは `int` しか入らないが変数の初期定義が `int | None` なために型エラーが発生している」といった箇所では、typing.cast() を利用して型を強制的にキャストさせています。

また、「呼び出し側が戻り値として `None` が返ることを全く想定していないコードなのに呼び出す関数自体は `None` が返る」箇所では (pts / dts 関連など) 、今まで `return None` としていた箇所を `return 0` に変更しました。
万が一実際に `return 0` の行が実行された場合、正常に動作するとは思えませんが、少なくとも `None` が返って例外でクラッシュするよりかは幾分かましだと思います。